### PR TITLE
feat: implement basic structure for AuthController with register and login endpoints

### DIFF
--- a/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
@@ -1,0 +1,11 @@
+package com.game.hub.gamehub.controllers;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+public class AuthController {
+
+
+}

--- a/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
@@ -1,5 +1,7 @@
 package com.game.hub.gamehub.controllers;
 
+import com.game.hub.gamehub.dtos.LoginRequest;
+import com.game.hub.gamehub.dtos.LoginResponse;
 import com.game.hub.gamehub.dtos.RegisterRequest;
 import com.game.hub.gamehub.dtos.RegisterResponse;
 import com.game.hub.gamehub.services.AuthService;
@@ -23,6 +25,12 @@ public class AuthController {
     @PostMapping("/register")
     public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest request) {
         RegisterResponse response = authService.register(request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        LoginResponse response = authService.login(request);
         return ResponseEntity.ok(response);
     }
 }

--- a/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
@@ -1,11 +1,28 @@
 package com.game.hub.gamehub.controllers;
 
+import com.game.hub.gamehub.dtos.RegisterRequest;
+import com.game.hub.gamehub.dtos.RegisterResponse;
+import com.game.hub.gamehub.services.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api")
+@RequestMapping("/api/auth")
 public class AuthController {
 
+    private final AuthService authService;
 
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<RegisterResponse> register(@RequestBody RegisterRequest request) {
+        RegisterResponse response = authService.register(request);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/controllers/AuthController.java
@@ -5,7 +5,6 @@ import com.game.hub.gamehub.dtos.LoginResponse;
 import com.game.hub.gamehub.dtos.RegisterRequest;
 import com.game.hub.gamehub.dtos.RegisterResponse;
 import com.game.hub.gamehub.services.AuthService;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/gamehub/src/main/java/com/game/hub/gamehub/dtos/LoginRequest.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/dtos/LoginRequest.java
@@ -1,0 +1,9 @@
+package com.game.hub.gamehub.dtos;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password
+) {}

--- a/gamehub/src/main/java/com/game/hub/gamehub/dtos/LoginResponse.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/dtos/LoginResponse.java
@@ -1,0 +1,5 @@
+package com.game.hub.gamehub.dtos;
+
+public record LoginResponse(
+        String token
+) {}

--- a/gamehub/src/main/java/com/game/hub/gamehub/dtos/RegisterRequest.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/dtos/RegisterRequest.java
@@ -1,0 +1,10 @@
+package com.game.hub.gamehub.dtos;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterRequest(
+        @NotBlank String username,
+        @NotBlank @Email String email,
+        @NotBlank String password
+) {}

--- a/gamehub/src/main/java/com/game/hub/gamehub/dtos/RegisterResponse.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/dtos/RegisterResponse.java
@@ -1,0 +1,5 @@
+package com.game.hub.gamehub.dtos;
+
+public record RegisterResponse(
+        String token
+) {}

--- a/gamehub/src/main/java/com/game/hub/gamehub/dtos/UserPrivateResponse.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/dtos/UserPrivateResponse.java
@@ -1,0 +1,14 @@
+package com.game.hub.gamehub.dtos;
+
+import com.game.hub.gamehub.enums.UserRank;
+import com.game.hub.gamehub.enums.UserRole;
+import java.util.UUID;
+
+public record UserPrivateResponse(
+        UUID id,
+        String username,
+        String email,
+        UserRole role,
+        UserRank rank,
+        int points
+) {}

--- a/gamehub/src/main/java/com/game/hub/gamehub/dtos/UserPublicResponse.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/dtos/UserPublicResponse.java
@@ -1,0 +1,11 @@
+package com.game.hub.gamehub.dtos;
+
+import com.game.hub.gamehub.enums.UserRank;
+import java.util.UUID;
+
+public record UserPublicResponse(
+        UUID id,
+        String username,
+        UserRank rank,
+        int points
+) {}

--- a/gamehub/src/main/java/com/game/hub/gamehub/mappers/UserMapper.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/mappers/UserMapper.java
@@ -1,0 +1,28 @@
+package com.game.hub.gamehub.mappers;
+
+import com.game.hub.gamehub.dtos.UserPrivateResponse;
+import com.game.hub.gamehub.dtos.UserPublicResponse;
+import com.game.hub.gamehub.models.User;
+
+public class UserMapper {
+
+    public static UserPrivateResponse toPrivate(User user) {
+        return new UserPrivateResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getRole(),
+                user.getRank(),
+                user.getPoints()
+        );
+    }
+
+    public static UserPublicResponse toPublic(User user) {
+        return new UserPublicResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getRank(),
+                user.getPoints()
+        );
+    }
+}

--- a/gamehub/src/main/java/com/game/hub/gamehub/services/AuthService.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/services/AuthService.java
@@ -1,0 +1,4 @@
+package com.game.hub.gamehub.services;
+
+public class AuthService {
+}

--- a/gamehub/src/main/java/com/game/hub/gamehub/services/AuthService.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/services/AuthService.java
@@ -1,4 +1,13 @@
 package com.game.hub.gamehub.services;
 
-public class AuthService {
+import com.game.hub.gamehub.dtos.LoginRequest;
+import com.game.hub.gamehub.dtos.LoginResponse;
+import com.game.hub.gamehub.dtos.RegisterRequest;
+import com.game.hub.gamehub.dtos.RegisterResponse;
+
+public interface AuthService {
+
+    RegisterResponse register(RegisterRequest request);
+    
+    LoginResponse login(LoginRequest request);
 }

--- a/gamehub/src/main/java/com/game/hub/gamehub/services/AuthServiceImpl.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/services/AuthServiceImpl.java
@@ -1,0 +1,23 @@
+package com.game.hub.gamehub.services;
+
+import com.game.hub.gamehub.dtos.LoginRequest;
+import com.game.hub.gamehub.dtos.LoginResponse;
+import com.game.hub.gamehub.dtos.RegisterRequest;
+import com.game.hub.gamehub.dtos.RegisterResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthServiceImpl implements AuthService {
+
+
+    @Override
+    public RegisterResponse register(RegisterRequest request) {
+        return null;
+    }
+
+    @Override
+    public LoginResponse login(LoginRequest request) {
+        return null;
+    }
+}
+


### PR DESCRIPTION
This PR includes the implementation of the base structure for the authentication flow. It includes:

POST /api/auth/register: Accepts user registration details and returns a JWT (logic pending).

POST /api/auth/login: Accepts user credentials and returns a JWT (logic pending).

Additionally:

Created DTOs for both requests and responses.

Added AuthService and AuthServiceImpl with empty method implementations to be completed.

Injected dependencies via constructor to avoid Lombok-related issues.