### PR TITLE
Develop

### DIFF
--- a/gamehub/src/main/java/com/game/hub/gamehub/controllers/UserController.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/controllers/UserController.java
@@ -1,0 +1,33 @@
+package com.game.hub.gamehub.controllers;
+
+import com.game.hub.gamehub.dtos.UserPrivateResponse;
+import com.game.hub.gamehub.dtos.UserPublicResponse;
+import com.game.hub.gamehub.services.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/{id}")
+    public ResponseEntity<UserPublicResponse> getUserById(@PathVariable UUID id) {
+        UserPublicResponse response = userService.getUserById(id);
+        return ResponseEntity.ok(response);
+    }
+
+    @PostMapping("/me")
+    public ResponseEntity<UserPrivateResponse> getCurrentUser() {
+        // Restringir acceso solo a roles PLAYER y ADMIN cuando Spring Security esté configurado
+        UserPrivateResponse response = userService.getCurrentUser();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/gamehub/src/main/java/com/game/hub/gamehub/services/UserService.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/services/UserService.java
@@ -1,0 +1,11 @@
+package com.game.hub.gamehub.services;
+
+import com.game.hub.gamehub.dtos.UserPrivateResponse;
+import com.game.hub.gamehub.dtos.UserPublicResponse;
+import java.util.UUID;
+
+public interface UserService {
+    UserPublicResponse getUserById(UUID id);
+    UserPrivateResponse getCurrentUser();
+}
+

--- a/gamehub/src/main/java/com/game/hub/gamehub/services/UserServiceImpl.java
+++ b/gamehub/src/main/java/com/game/hub/gamehub/services/UserServiceImpl.java
@@ -1,0 +1,47 @@
+package com.game.hub.gamehub.services;
+
+import com.game.hub.gamehub.dtos.UserPrivateResponse;
+import com.game.hub.gamehub.dtos.UserPublicResponse;
+import com.game.hub.gamehub.models.User;
+import com.game.hub.gamehub.repositories.UserRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    public UserServiceImpl(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserPublicResponse getUserById(UUID id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+        return new UserPublicResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getRank(),
+                user.getPoints()
+        );
+    }
+
+    @Override
+    public UserPrivateResponse getCurrentUser() {
+        // Reemplazar por usuario autenticado cuando Spring Security esté configurado
+        UUID mockUserId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        User user = userRepository.findById(mockUserId)
+                .orElseThrow(() -> new RuntimeException("Usuario no encontrado"));
+        return new UserPrivateResponse(
+                user.getId(),
+                user.getUsername(),
+                user.getEmail(),
+                user.getRole(),
+                user.getRank(),
+                user.getPoints()
+        );
+    }
+}


### PR DESCRIPTION
Implemented user-related endpoints:

- `POST /api/users/{id}`: returns public information of any user.
- `POST /api/users/me`: returns private data of the current user.

### Notes
- Security is not enforced yet. Role-based access control will be applied once Spring Security is integrated.
- A mock user ID is used for testing `GET /me`.

### Next Steps
- Replace the mock user logic with authenticated user data.
- Protect `/me` to allow access only for `PLAYER` and `ADMIN` roles.
